### PR TITLE
Make response HTTP spec compliant

### DIFF
--- a/rootfs/var/www/localhost/htdocs/snapshot.cgi
+++ b/rootfs/var/www/localhost/htdocs/snapshot.cgi
@@ -3,7 +3,7 @@
 URL="$(</tmp/url)"
 timestamp=$(date +%Y-%m-%d_%H-%M-%S-%3N)
 ffmpeg -y -rtsp_transport tcp -i $URL -frames:v 1 /var/www/localhost/htdocs/snapshots/snapshot_$timestamp.jpg -loglevel panic
-echo "Content-type: text/html" 
-echo "Status: 302"
-echo "Location: snapshots/snapshot_$timestamp.jpg"
-echo
+echo -e "Content-type: text/html\r" 
+echo -e "Status: 302\r"
+echo -e "Location: snapshots/snapshot_$timestamp.jpg\r"
+echo -e "\r"


### PR DESCRIPTION
As of NodeJS 16.16.x Nodejs rejects HTTP responses that do not meet the spec

This patch makes the head compliant by ending lines with CRLF

See for details: 

https://github.com/node-red/node-red/issues/3772